### PR TITLE
feat(analyzer): interval property name analyzer

### DIFF
--- a/Azure.MgmtSdk.Analyzers.Test/IntervalPropertyNameAnalyzerTests.cs
+++ b/Azure.MgmtSdk.Analyzers.Test/IntervalPropertyNameAnalyzerTests.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
+using VerifyCS = AzureMgmtSDKAnalyzer.Test.CSharpAnalyzerVerifier<
+    Azure.MgmtSdk.Analyzers.IntervalPropertyNameAnalyzer>;
+
+namespace Azure.MgmtSdk.Analyzers.Test
+{
+    [TestClass]
+    public class IntervalPropertyNameAnalyzerTests
+    {
+        [TestMethod]
+        public async Task AZM0020PublicBoolTypeWithVerbPrefix()
+        {
+            var test = @"namespace Azure.ResourceManager.Network
+{
+    public partial class Test
+    {
+        public int TestIntervalInSeconds { get; set; }
+        public int TestDurationInSeconds { get; set; }
+        public int Foo { get; set; }
+        public bool TestInterval { get; set; }
+        public int IntervalInSeconds { get; set; }
+        public int IntervalInMinutes { get; set; }
+    }
+}";
+            await VerifyCS.VerifyAnalyzerAsync(test); // Default No errors.
+        }
+
+        [TestMethod]
+        public async Task AZM0020PublicBoolTypeWithoutVerbPrefix()
+        {
+            var test = @"namespace Azure.ResourceManager.Network
+{
+    public partial class Test
+    {
+        public int FipInterval { get; set; }
+        public int FipDuration { get; set; }
+        public int Interval { get; set; }
+        public int Duration { get; set; }
+    }
+}";
+            await VerifyCS.VerifyAnalyzerAsync(test,
+                VerifyCS.Diagnostic(IntervalPropertyNameAnalyzer.DiagnosticId).WithSpan(5, 20, 5, 31).WithArguments("FipInterval"),
+                VerifyCS.Diagnostic(IntervalPropertyNameAnalyzer.DiagnosticId).WithSpan(6, 20, 6, 31).WithArguments("FipDuration"),
+                VerifyCS.Diagnostic(IntervalPropertyNameAnalyzer.DiagnosticId).WithSpan(7, 20, 7, 28).WithArguments("Interval"),
+                VerifyCS.Diagnostic(IntervalPropertyNameAnalyzer.DiagnosticId).WithSpan(8, 20, 8, 28).WithArguments("Duration")
+            );
+        }
+    }
+}

--- a/Azure.MgmtSdk.Analyzers.Test/IntervalPropertyNameAnalyzerTests.cs
+++ b/Azure.MgmtSdk.Analyzers.Test/IntervalPropertyNameAnalyzerTests.cs
@@ -9,9 +9,12 @@ namespace Azure.MgmtSdk.Analyzers.Test
     public class IntervalPropertyNameAnalyzerTests
     {
         [TestMethod]
-        public async Task AZM0020PublicBoolTypeWithVerbPrefix()
+        public async Task ValidCases()
         {
-            var test = @"namespace Azure.ResourceManager.Network
+            var test = @"using System.Collections.Generic;
+using System.Collections;
+
+namespace Azure.ResourceManager.Network
 {
     public partial class Test
     {
@@ -19,6 +22,9 @@ namespace Azure.MgmtSdk.Analyzers.Test
         public int TestDurationInSeconds { get; set; }
         public int Foo { get; set; }
         public bool TestInterval { get; set; }
+        public string StringInterval { get; set; }
+        public double DoubleInterval { get; set; }
+        public IList<string> IListInterval { get; set; }
         public int IntervalInSeconds { get; set; }
         public int IntervalInMinutes { get; set; }
     }
@@ -27,7 +33,7 @@ namespace Azure.MgmtSdk.Analyzers.Test
         }
 
         [TestMethod]
-        public async Task AZM0020PublicBoolTypeWithoutVerbPrefix()
+        public async Task ErrorCases()
         {
             var test = @"namespace Azure.ResourceManager.Network
 {
@@ -35,15 +41,21 @@ namespace Azure.MgmtSdk.Analyzers.Test
     {
         public int FipInterval { get; set; }
         public int FipDuration { get; set; }
-        public int Interval { get; set; }
-        public int Duration { get; set; }
+        public uint Interval { get; set; }
+        public short Duration { get; set; }
+        public ushort Uint16Interval { get; set; }
+        public long Int64Interval { get; set; }
+        public ulong Uint64Duration { get; set; }
     }
 }";
             await VerifyCS.VerifyAnalyzerAsync(test,
                 VerifyCS.Diagnostic(IntervalPropertyNameAnalyzer.DiagnosticId).WithSpan(5, 20, 5, 31).WithArguments("FipInterval"),
                 VerifyCS.Diagnostic(IntervalPropertyNameAnalyzer.DiagnosticId).WithSpan(6, 20, 6, 31).WithArguments("FipDuration"),
-                VerifyCS.Diagnostic(IntervalPropertyNameAnalyzer.DiagnosticId).WithSpan(7, 20, 7, 28).WithArguments("Interval"),
-                VerifyCS.Diagnostic(IntervalPropertyNameAnalyzer.DiagnosticId).WithSpan(8, 20, 8, 28).WithArguments("Duration")
+                VerifyCS.Diagnostic(IntervalPropertyNameAnalyzer.DiagnosticId).WithSpan(7, 21, 7, 29).WithArguments("Interval"),
+                VerifyCS.Diagnostic(IntervalPropertyNameAnalyzer.DiagnosticId).WithSpan(8, 22, 8, 30).WithArguments("Duration"),
+                VerifyCS.Diagnostic(IntervalPropertyNameAnalyzer.DiagnosticId).WithSpan(9, 23, 9, 37).WithArguments("Uint16Interval"),
+                VerifyCS.Diagnostic(IntervalPropertyNameAnalyzer.DiagnosticId).WithSpan(10, 21, 10, 34).WithArguments("Int64Interval"),
+                VerifyCS.Diagnostic(IntervalPropertyNameAnalyzer.DiagnosticId).WithSpan(11, 22, 11, 36).WithArguments("Uint64Duration")
             );
         }
     }

--- a/Azure.MgmtSdk.Analyzers/IntervalPropertyNameAnalyzer.cs
+++ b/Azure.MgmtSdk.Analyzers/IntervalPropertyNameAnalyzer.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Azure.MgmtSdk.Analyzers
+{
+    /// <summary>
+    /// Analyzer to check interval property name.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class IntervalPropertyNameAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "AZM0030";
+
+        protected static readonly string Title = "Improper interval property name";
+        protected static readonly string MessageFormat = "Property name '{0}' should end with units.";
+        protected static readonly string Description = "Property is of integer type. Consider to append unit to the name, like \"InSeconds\".";
+
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title,
+            MessageFormat, DiagnosticCategory.Naming, DiagnosticSeverity.Warning, isEnabledByDefault: true,
+            description: Description);
+
+        private static readonly Regex SuffixRegex = new Regex("((Interval)|(Duration))$");
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.EnableConcurrentExecution();
+            context.RegisterSymbolAction(AnalyzeIntervalProperty, SymbolKind.Property);
+        }
+
+        private void AnalyzeIntervalProperty(SymbolAnalysisContext context)
+        {
+            var name = context.Symbol.Name;
+            if (SuffixRegex.IsMatch(name))
+            {
+                var type = ((IPropertySymbol)context.Symbol).Type;
+
+                switch (type.SpecialType)
+                {
+                    case SpecialType.System_Int16:
+                    case SpecialType.System_Int32:
+                    case SpecialType.System_Int64:
+                    case SpecialType.System_UInt16:
+                    case SpecialType.System_UInt32:
+                    case SpecialType.System_UInt64:
+                        var diagnostic = Diagnostic.Create(Rule, context.Symbol.Locations[0], name);
+                        context.ReportDiagnostic(diagnostic);
+                        break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- add an analyzer which will check the following properties to raise warning that the name should has unit suffixes like `InSeconds`
  - integer type
  - name ends with `Interval` or `Duration`
- add unit tests