### PR TITLE
Data property 

### DIFF
--- a/Azure.MgmtSdk.Analyzers.CodeFixes/ModelNameSuffixCodeFixProvider.cs
+++ b/Azure.MgmtSdk.Analyzers.CodeFixes/ModelNameSuffixCodeFixProvider.cs
@@ -16,7 +16,7 @@ namespace Azure.MgmtSdk.Analyzers
     {
         public sealed override ImmutableArray<string> FixableDiagnosticIds
         {
-            get { return ImmutableArray.Create(ModelNameSuffixGeneralAnalyzer.DiagnosticIdGeneral); }
+            get { return ImmutableArray.Create(ModelNameSuffixGeneralAnalyzer.DiagnosticId); }
         }
 
         public sealed override FixAllProvider GetFixAllProvider()

--- a/Azure.MgmtSdk.Analyzers.Test/DataPropertyEtagAnalyzerTests.cs
+++ b/Azure.MgmtSdk.Analyzers.Test/DataPropertyEtagAnalyzerTests.cs
@@ -37,7 +37,6 @@ namespace Azure.MgmtSdk.Analyzers.Test
     }
 }";
             await VerifyCS.VerifyAnalyzerAsync(test1, VerifyCS.Diagnostic(DataPropertyEtagAnalyzer.DiagnosticId).WithSpan(5, 23, 5, 27).WithArguments("Etag", "string"));
-            //await VerifyCS.VerifyAnalyzerAsync(test2, VerifyCS.Diagnostic(DataPropertyEtagAnalyzer.DiagnosticId).WithSpan(5, 39, 5, 43).WithArguments("Etag", "string"));
         }
 
     }

--- a/Azure.MgmtSdk.Analyzers.Test/DataPropertyEtagAnalyzerTests.cs
+++ b/Azure.MgmtSdk.Analyzers.Test/DataPropertyEtagAnalyzerTests.cs
@@ -9,9 +9,9 @@ namespace Azure.MgmtSdk.Analyzers.Test
     public class DataPropertyEtagTests
     {
         [TestMethod]
-        public async Task AZM0043DataPropertyEtagCorrectVariableType()
+        public async Task ValidCases()
         {
-            var test = @"namespace Azure.ResourceManager.Network
+            var test1 = @"namespace Azure.ResourceManager.Network
 {
     public partial class Test
     {
@@ -23,35 +23,22 @@ namespace Azure.MgmtSdk.Analyzers.Test
 #nullable disable
     }
 }";
-            await VerifyCS.VerifyAnalyzerAsync(test); // Default No errors.
+            await VerifyCS.VerifyAnalyzerAsync(test1);
         }
 
         [TestMethod]
-        public async Task AZM0043DataPropertyEtagInCorrectPropertyType()
+        public async Task ErrorCases()
         {
-            var test = @"namespace Azure.ResourceManager.Network
+            var test1 = @"namespace Azure.ResourceManager.Network
 {
     public partial class Test
     {
         public string Etag { get; set; }
     }
 }";
-            var expected = VerifyCS.Diagnostic(DataPropertyEtagAnalyzer.DiagnosticId).WithSpan(5, 23, 5, 27).WithArguments("Etag", "string");
-            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+            await VerifyCS.VerifyAnalyzerAsync(test1, VerifyCS.Diagnostic(DataPropertyEtagAnalyzer.DiagnosticId).WithSpan(5, 23, 5, 27).WithArguments("Etag", "string"));
+            //await VerifyCS.VerifyAnalyzerAsync(test2, VerifyCS.Diagnostic(DataPropertyEtagAnalyzer.DiagnosticId).WithSpan(5, 39, 5, 43).WithArguments("Etag", "string"));
         }
 
-        [TestMethod]
-        public async Task AZM0043DataPropertyEtagIncorrectVariableType()
-        {
-            var test = @"namespace Azure.ResourceManager.Network
-{
-    public partial class Test
-    {
-        public static readonly string Etag;    
-    }
-}";
-            var expected = VerifyCS.Diagnostic(DataPropertyEtagAnalyzer.DiagnosticId).WithSpan(5, 39, 5, 43).WithArguments("Etag", "string");
-            await VerifyCS.VerifyAnalyzerAsync(test, expected);
-        }
     }
 }

--- a/Azure.MgmtSdk.Analyzers.Test/DataPropertyEtagAnalyzerTests.cs
+++ b/Azure.MgmtSdk.Analyzers.Test/DataPropertyEtagAnalyzerTests.cs
@@ -36,7 +36,7 @@ namespace Azure.MgmtSdk.Analyzers.Test
         public string Etag { get; set; }
     }
 }";
-            var expected = VerifyCS.Diagnostic(DataPropertyEtagAnalyzer.DiagnosticIdDataPropertyETagName).WithSpan(5, 23, 5, 27).WithArguments("Etag", "string");
+            var expected = VerifyCS.Diagnostic(DataPropertyEtagAnalyzer.DiagnosticId).WithSpan(5, 23, 5, 27).WithArguments("Etag", "string");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -50,7 +50,7 @@ namespace Azure.MgmtSdk.Analyzers.Test
         public static readonly string Etag;    
     }
 }";
-            var expected = VerifyCS.Diagnostic(DataPropertyEtagAnalyzer.DiagnosticIdDataPropertyETagName).WithSpan(5, 39, 5, 43).WithArguments("Etag", "string");
+            var expected = VerifyCS.Diagnostic(DataPropertyEtagAnalyzer.DiagnosticId).WithSpan(5, 39, 5, 43).WithArguments("Etag", "string");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
     }

--- a/Azure.MgmtSdk.Analyzers.Test/DataPropertyEtagAnalyzerTests.cs
+++ b/Azure.MgmtSdk.Analyzers.Test/DataPropertyEtagAnalyzerTests.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
+using VerifyCS = AzureMgmtSDKAnalyzer.Test.CSharpAnalyzerVerifier<
+    Azure.MgmtSdk.Analyzers.DataPropertyEtagAnalyzer>;
+
+namespace Azure.MgmtSdk.Analyzers.Test
+{
+    [TestClass]
+    public class DataPropertyEtagTests
+    {
+        [TestMethod]
+        public async Task AZM0043DataPropertyEtagCorrectVariableType()
+        {
+            var test = @"namespace Azure.ResourceManager.Network
+{
+    public partial class Test
+    {
+        public class ETag
+        {
+        }
+#nullable enable
+        public ETag? Etag { get; }
+#nullable disable
+    }
+}";
+            await VerifyCS.VerifyAnalyzerAsync(test); // Default No errors.
+        }
+
+        [TestMethod]
+        public async Task AZM0043DataPropertyEtagInCorrectPropertyType()
+        {
+            var test = @"namespace Azure.ResourceManager.Network
+{
+    public partial class Test
+    {
+        public string Etag { get; set; }
+    }
+}";
+            var expected = VerifyCS.Diagnostic(DataPropertyEtagAnalyzer.DiagnosticIdDataPropertyETagName).WithSpan(5, 23, 5, 27).WithArguments("Etag", "string");
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task AZM0043DataPropertyEtagIncorrectVariableType()
+        {
+            var test = @"namespace Azure.ResourceManager.Network
+{
+    public partial class Test
+    {
+        public static readonly string Etag;    
+    }
+}";
+            var expected = VerifyCS.Diagnostic(DataPropertyEtagAnalyzer.DiagnosticIdDataPropertyETagName).WithSpan(5, 39, 5, 43).WithArguments("Etag", "string");
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+    }
+}

--- a/Azure.MgmtSdk.Analyzers.Test/DataPropertyResourceIdentifierAnalyzerTests.cs
+++ b/Azure.MgmtSdk.Analyzers.Test/DataPropertyResourceIdentifierAnalyzerTests.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
+using VerifyCS = AzureMgmtSDKAnalyzer.Test.CSharpAnalyzerVerifier<
+    Azure.MgmtSdk.Analyzers.DataPropertyResourceIdentifierAnalyzer>;
+
+namespace Azure.MgmtSdk.Analyzers.Test
+{
+    [TestClass]
+    public class DataPropertyResourceIdentifierAnalyzerTests
+    {
+        [TestMethod]
+        public async Task AZM0041DataPropertyResourceIdentifierCorrectPropertyType()
+        {
+            var test = @"
+namespace Azure.ResourceManager.Network
+{
+    public class ResourceIdentifier
+    {
+    }
+    public partial class Test
+    {
+        public ResourceIdentifier DefaultOriginGroupId { get; set; }
+    }
+}";
+            await VerifyCS.VerifyAnalyzerAsync(test); // Default No errors.
+        }
+
+        [TestMethod]
+        public async Task AZM0041DataPropertyResourceIdentifierIncorrectPropertyType()
+        {
+            var test = @"namespace Azure.ResourceManager.Network
+{
+    public partial class Test
+    {
+        public string DefaultOriginGroupId { get; set; }
+    }
+}";
+            var expected = VerifyCS.Diagnostic(DataPropertyResourceIdentifierAnalyzer.DiagnosticIdDataPropertyResourceIdentifierName).WithSpan(5, 23, 5, 43).WithArguments("DefaultOriginGroupId", "string");
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task AZM0041DataPropertyResourceIdentifierIncorrectVariableType()
+        {
+            var test = @"namespace Azure.ResourceManager.Network
+{
+    public partial class Test
+    {
+        public static readonly string DefaultOriginGroupId; 
+    }
+}";
+            var expected = VerifyCS.Diagnostic(DataPropertyResourceIdentifierAnalyzer.DiagnosticIdDataPropertyResourceIdentifierName).WithSpan(5, 39, 5, 59).WithArguments("DefaultOriginGroupId", "string");
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+    }
+}

--- a/Azure.MgmtSdk.Analyzers.Test/DataPropertyResourceIdentifierAnalyzerTests.cs
+++ b/Azure.MgmtSdk.Analyzers.Test/DataPropertyResourceIdentifierAnalyzerTests.cs
@@ -9,9 +9,9 @@ namespace Azure.MgmtSdk.Analyzers.Test
     public class DataPropertyResourceIdentifierAnalyzerTests
     {
         [TestMethod]
-        public async Task AZM0041DataPropertyResourceIdentifierCorrectPropertyType()
+        public async Task ValidCases()
         {
-            var test = @"
+            var test1 = @"
 namespace Azure.ResourceManager.Network
 {
     public class ResourceIdentifier
@@ -22,35 +22,28 @@ namespace Azure.ResourceManager.Network
         public ResourceIdentifier DefaultOriginGroupId { get; set; }
     }
 }";
-            await VerifyCS.VerifyAnalyzerAsync(test); // Default No errors.
+            await VerifyCS.VerifyAnalyzerAsync(test1); 
         }
 
         [TestMethod]
-        public async Task AZM0041DataPropertyResourceIdentifierIncorrectPropertyType()
+        public async Task ErrorCases()
         {
-            var test = @"namespace Azure.ResourceManager.Network
+            var test1 = @"namespace Azure.ResourceManager.Network
 {
     public partial class Test
     {
-        public string DefaultOriginGroupId { get; set; }
+        public string DefaultOriginGroupResourceIdentifier { get; set; }
     }
 }";
-            var expected = VerifyCS.Diagnostic(DataPropertyResourceIdentifierAnalyzer.DiagnosticId).WithSpan(5, 23, 5, 43).WithArguments("DefaultOriginGroupId", "string");
-            await VerifyCS.VerifyAnalyzerAsync(test, expected);
-        }
-
-        [TestMethod]
-        public async Task AZM0041DataPropertyResourceIdentifierIncorrectVariableType()
-        {
-            var test = @"namespace Azure.ResourceManager.Network
+            var test2 = @"namespace Azure.ResourceManager.Network
 {
     public partial class Test
     {
-        public static readonly string DefaultOriginGroupId; 
+        public static readonly string DefaultOriginGroupResourceIdentifier; 
     }
 }";
-            var expected = VerifyCS.Diagnostic(DataPropertyResourceIdentifierAnalyzer.DiagnosticId).WithSpan(5, 39, 5, 59).WithArguments("DefaultOriginGroupId", "string");
-            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+            await VerifyCS.VerifyAnalyzerAsync(test1, VerifyCS.Diagnostic(DataPropertyResourceIdentifierAnalyzer.DiagnosticId).WithSpan(5, 23, 5, 59).WithArguments("DefaultOriginGroupResourceIdentifier", "string"));
+            await VerifyCS.VerifyAnalyzerAsync(test2, VerifyCS.Diagnostic(DataPropertyResourceIdentifierAnalyzer.DiagnosticId).WithSpan(5, 39, 5, 75).WithArguments("DefaultOriginGroupResourceIdentifier", "string"));
         }
     }
 }

--- a/Azure.MgmtSdk.Analyzers.Test/DataPropertyResourceIdentifierAnalyzerTests.cs
+++ b/Azure.MgmtSdk.Analyzers.Test/DataPropertyResourceIdentifierAnalyzerTests.cs
@@ -35,7 +35,7 @@ namespace Azure.ResourceManager.Network
         public string DefaultOriginGroupId { get; set; }
     }
 }";
-            var expected = VerifyCS.Diagnostic(DataPropertyResourceIdentifierAnalyzer.DiagnosticIdDataPropertyResourceIdentifierName).WithSpan(5, 23, 5, 43).WithArguments("DefaultOriginGroupId", "string");
+            var expected = VerifyCS.Diagnostic(DataPropertyResourceIdentifierAnalyzer.DiagnosticId).WithSpan(5, 23, 5, 43).WithArguments("DefaultOriginGroupId", "string");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -49,7 +49,7 @@ namespace Azure.ResourceManager.Network
         public static readonly string DefaultOriginGroupId; 
     }
 }";
-            var expected = VerifyCS.Diagnostic(DataPropertyResourceIdentifierAnalyzer.DiagnosticIdDataPropertyResourceIdentifierName).WithSpan(5, 39, 5, 59).WithArguments("DefaultOriginGroupId", "string");
+            var expected = VerifyCS.Diagnostic(DataPropertyResourceIdentifierAnalyzer.DiagnosticId).WithSpan(5, 39, 5, 59).WithArguments("DefaultOriginGroupId", "string");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
     }

--- a/Azure.MgmtSdk.Analyzers.Test/DataPropertyResourceTypeAnalyzerTests.cs
+++ b/Azure.MgmtSdk.Analyzers.Test/DataPropertyResourceTypeAnalyzerTests.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
+using VerifyCS = AzureMgmtSDKAnalyzer.Test.CSharpAnalyzerVerifier<
+    Azure.MgmtSdk.Analyzers.DataPropertyResourceTypeAnalyzer>;
+
+namespace Azure.MgmtSdk.Analyzers.Test
+{
+    [TestClass]
+    public class DataPropertyResourceTypeAnalyzerTests
+    {
+        [TestMethod]
+        public async Task AZM0042DataPropertyResourceTypeCorrectType()
+        {
+            var test = @"
+namespace Azure.ResourceManager.Network
+{
+    public class ResourceType
+    {
+    }
+    public partial class Test
+    {
+        public static readonly ResourceType ResourceType;
+    }
+}";
+            await VerifyCS.VerifyAnalyzerAsync(test); // Default No errors.
+        }
+
+        [TestMethod]
+        public async Task AZM0042DataPropertyResourceTypeIncorrectType()
+        {
+            var test = @"namespace Azure.ResourceManager.Network
+{
+    public partial class Test
+    {
+        public string ResourceType { get; set; }
+    }
+}";
+            var expected = VerifyCS.Diagnostic(DataPropertyResourceTypeAnalyzer.DiagnosticIdDataPropertyResourceTypeName).WithSpan(5, 23, 5, 35).WithArguments("ResourceType", "string");
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [TestMethod]
+        public async Task AZM0042DataPropertyResourceTypeIncorrectVariableType()
+        {
+            var test = @"namespace Azure.ResourceManager.Network
+{
+    public partial class Test
+    {
+        public static readonly string ResourceType;    
+    }
+}";
+            var expected = VerifyCS.Diagnostic(DataPropertyResourceTypeAnalyzer.DiagnosticIdDataPropertyResourceTypeName).WithSpan(5, 39, 5, 51).WithArguments("ResourceType", "string");
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+    }
+}

--- a/Azure.MgmtSdk.Analyzers.Test/DataPropertyResourceTypeAnalyzerTests.cs
+++ b/Azure.MgmtSdk.Analyzers.Test/DataPropertyResourceTypeAnalyzerTests.cs
@@ -9,9 +9,9 @@ namespace Azure.MgmtSdk.Analyzers.Test
     public class DataPropertyResourceTypeAnalyzerTests
     {
         [TestMethod]
-        public async Task AZM0042DataPropertyResourceTypeCorrectType()
+        public async Task ValidCases()
         {
-            var test = @"
+            var test1 = @"
 namespace Azure.ResourceManager.Network
 {
     public class ResourceType
@@ -22,35 +22,28 @@ namespace Azure.ResourceManager.Network
         public static readonly ResourceType ResourceType;
     }
 }";
-            await VerifyCS.VerifyAnalyzerAsync(test); // Default No errors.
+            await VerifyCS.VerifyAnalyzerAsync(test1);
         }
 
         [TestMethod]
-        public async Task AZM0042DataPropertyResourceTypeIncorrectType()
+        public async Task ErrorCases()
         {
-            var test = @"namespace Azure.ResourceManager.Network
+            var test1 = @"namespace Azure.ResourceManager.Network
 {
     public partial class Test
     {
         public string ResourceType { get; set; }
     }
 }";
-            var expected = VerifyCS.Diagnostic(DataPropertyResourceTypeAnalyzer.DiagnosticId).WithSpan(5, 23, 5, 35).WithArguments("ResourceType", "string");
-            await VerifyCS.VerifyAnalyzerAsync(test, expected);
-        }
-
-        [TestMethod]
-        public async Task AZM0042DataPropertyResourceTypeIncorrectVariableType()
-        {
-            var test = @"namespace Azure.ResourceManager.Network
+            var test2 = @"namespace Azure.ResourceManager.Network
 {
     public partial class Test
     {
         public static readonly string ResourceType;    
     }
 }";
-            var expected = VerifyCS.Diagnostic(DataPropertyResourceTypeAnalyzer.DiagnosticId).WithSpan(5, 39, 5, 51).WithArguments("ResourceType", "string");
-            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+            await VerifyCS.VerifyAnalyzerAsync(test1, VerifyCS.Diagnostic(DataPropertyResourceTypeAnalyzer.DiagnosticId).WithSpan(5, 23, 5, 35).WithArguments("ResourceType", "string"));
+            await VerifyCS.VerifyAnalyzerAsync(test2, VerifyCS.Diagnostic(DataPropertyResourceTypeAnalyzer.DiagnosticId).WithSpan(5, 39, 5, 51).WithArguments("ResourceType", "string"));
         }
     }
 }

--- a/Azure.MgmtSdk.Analyzers.Test/DataPropertyResourceTypeAnalyzerTests.cs
+++ b/Azure.MgmtSdk.Analyzers.Test/DataPropertyResourceTypeAnalyzerTests.cs
@@ -35,7 +35,7 @@ namespace Azure.ResourceManager.Network
         public string ResourceType { get; set; }
     }
 }";
-            var expected = VerifyCS.Diagnostic(DataPropertyResourceTypeAnalyzer.DiagnosticIdDataPropertyResourceTypeName).WithSpan(5, 23, 5, 35).WithArguments("ResourceType", "string");
+            var expected = VerifyCS.Diagnostic(DataPropertyResourceTypeAnalyzer.DiagnosticId).WithSpan(5, 23, 5, 35).WithArguments("ResourceType", "string");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -49,7 +49,7 @@ namespace Azure.ResourceManager.Network
         public static readonly string ResourceType;    
     }
 }";
-            var expected = VerifyCS.Diagnostic(DataPropertyResourceTypeAnalyzer.DiagnosticIdDataPropertyResourceTypeName).WithSpan(5, 39, 5, 51).WithArguments("ResourceType", "string");
+            var expected = VerifyCS.Diagnostic(DataPropertyResourceTypeAnalyzer.DiagnosticId).WithSpan(5, 39, 5, 51).WithArguments("ResourceType", "string");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
     }

--- a/Azure.MgmtSdk.Analyzers.Test/ModelNameSuffixDataTests.cs
+++ b/Azure.MgmtSdk.Analyzers.Test/ModelNameSuffixDataTests.cs
@@ -40,7 +40,7 @@ namespace Azure.ResourceManager.Network.Models
     {
     }
 }";
-            var expected = VerifyCS.Diagnostic(ModelNameSuffixDataAnalyzer.DiagnosticIdData).WithSpan(6, 26, 6, 47).WithArguments("AadAuthenticationData", "Data");
+            var expected = VerifyCS.Diagnostic(ModelNameSuffixDataAnalyzer.DiagnosticId).WithSpan(6, 26, 6, 47).WithArguments("AadAuthenticationData", "Data");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 

--- a/Azure.MgmtSdk.Analyzers.Test/ModelNameSuffixDefinitionTests.cs
+++ b/Azure.MgmtSdk.Analyzers.Test/ModelNameSuffixDefinitionTests.cs
@@ -23,7 +23,7 @@ namespace Azure.ResourceManager.Network.Models
     {
     }
 }";
-            var expected = VerifyCS.Diagnostic(ModelNameSuffixDefinitionAnalyzer.DiagnosticIdDefinition).WithSpan(4, 26, 4, 53).WithArguments("AadAuthenticationDefinition", "Definition");
+            var expected = VerifyCS.Diagnostic(ModelNameSuffixDefinitionAnalyzer.DiagnosticId).WithSpan(4, 26, 4, 53).WithArguments("AadAuthenticationDefinition", "Definition");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 

--- a/Azure.MgmtSdk.Analyzers.Test/ModelNameSuffixGeneralTests.cs
+++ b/Azure.MgmtSdk.Analyzers.Test/ModelNameSuffixGeneralTests.cs
@@ -33,7 +33,7 @@ class MonitorResult
     {
     }
 }";
-            var expected = VerifyCS.Diagnostic(ModelNameSuffixGeneralAnalyzer.DiagnosticIdGeneral).WithSpan(3, 18, 3, 36).WithArguments("ResponseParameters", "Parameters");
+            var expected = VerifyCS.Diagnostic(ModelNameSuffixGeneralAnalyzer.DiagnosticId).WithSpan(3, 18, 3, 36).WithArguments("ResponseParameters", "Parameters");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -49,7 +49,7 @@ class MonitorResult
         }
     }
 }";
-            var expected = VerifyCS.Diagnostic(ModelNameSuffixGeneralAnalyzer.DiagnosticIdGeneral).WithSpan(3, 18, 3, 35).WithArguments("ResponseParameter", "Parameter");
+            var expected = VerifyCS.Diagnostic(ModelNameSuffixGeneralAnalyzer.DiagnosticId).WithSpan(3, 18, 3, 35).WithArguments("ResponseParameter", "Parameter");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -68,7 +68,7 @@ class MonitorResult
         }
     }
 }";
-            var expected = VerifyCS.Diagnostic(ModelNameSuffixGeneralAnalyzer.DiagnosticIdGeneral).WithSpan(5, 22, 5, 39).WithArguments("ResponseParameter", "Parameter");
+            var expected = VerifyCS.Diagnostic(ModelNameSuffixGeneralAnalyzer.DiagnosticId).WithSpan(5, 22, 5, 39).WithArguments("ResponseParameter", "Parameter");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
     }

--- a/Azure.MgmtSdk.Analyzers.Test/ModelNameSuffixOperationTests.cs
+++ b/Azure.MgmtSdk.Analyzers.Test/ModelNameSuffixOperationTests.cs
@@ -42,7 +42,7 @@ namespace Azure.ResourceManager.Network.Models
     {
     }
 }";
-            DiagnosticResult[] expected = { VerifyCS.Diagnostic(ModelNameSuffixOperationAnalyzer.DiagnosticIdOperation).WithSpan(4, 18, 4, 30).WithArguments("ArmOperation", "Operation"), VerifyCS.Diagnostic(ModelNameSuffixOperationAnalyzer.DiagnosticIdOperation).WithSpan(7, 20, 7, 35).WithArguments("DnsArmOperation", "Operation") };
+            DiagnosticResult[] expected = { VerifyCS.Diagnostic(ModelNameSuffixOperationAnalyzer.DiagnosticId).WithSpan(4, 18, 4, 30).WithArguments("ArmOperation", "Operation"), VerifyCS.Diagnostic(ModelNameSuffixOperationAnalyzer.DiagnosticId).WithSpan(7, 20, 7, 35).WithArguments("DnsArmOperation", "Operation") };
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
     }

--- a/Azure.MgmtSdk.Analyzers.Test/ModelNameSuffixResourceTests.cs
+++ b/Azure.MgmtSdk.Analyzers.Test/ModelNameSuffixResourceTests.cs
@@ -33,7 +33,7 @@ class MonitorResult
     {
     }
 }";
-            var expected = VerifyCS.Diagnostic(ModelNameSuffixResourceAnalyzer.DiagnosticIdResource).WithSpan(3, 18, 3, 30).WithArguments("TestResource", "Resource");
+            var expected = VerifyCS.Diagnostic(ModelNameSuffixResourceAnalyzer.DiagnosticId).WithSpan(3, 18, 3, 30).WithArguments("TestResource", "Resource");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 

--- a/Azure.MgmtSdk.Analyzers.Test/PublicBoolPropertyNameTests.cs
+++ b/Azure.MgmtSdk.Analyzers.Test/PublicBoolPropertyNameTests.cs
@@ -31,7 +31,7 @@ namespace Azure.MgmtSdk.Analyzers.Test
         public bool? Fips { get; set; }
     }
 }";
-            var expected = VerifyCS.Diagnostic(PublicBoolPropertyNameAnalyzer.DiagnosticIdPublicBoolPropertyName).WithSpan(5, 22, 5, 26).WithArguments("Fips", "Fips");
+            var expected = VerifyCS.Diagnostic(PublicBoolPropertyNameAnalyzer.DiagnosticId).WithSpan(5, 22, 5, 26).WithArguments("Fips", "Fips");
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
     }

--- a/Azure.MgmtSdk.Analyzers/DataPropertyAnalyzerBase.cs
+++ b/Azure.MgmtSdk.Analyzers/DataPropertyAnalyzerBase.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Data;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Azure.MgmtSdk.Analyzers
+{
+    /// <summary>
+    /// Analyzer to check type name suffixes. This file contains the base class.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class DataPropertyAnalyzerBase : DiagnosticAnalyzer
+    {
+        protected static readonly string Title = "Potential improper data type of propert";
+        protected static readonly string MessageFormat = "Property {0} looks like an '{1}'.";
+        protected static readonly string Description = "Check the real return value and consider changing the type to '{1}'.";
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray<DiagnosticDescriptor>.Empty;
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.EnableConcurrentExecution();
+        }
+
+        protected void MatchAndDiagnostic(Regex suffixRegex, string variableName, string variableType, List<string> targetName, List<string> targetType, DiagnosticDescriptor Rule, SyntaxNodeAnalysisContext context)
+        {
+            var match = suffixRegex.Match(variableName);
+            //Console.WriteLine("match: ", match);
+
+            if (match.Success || targetName.Exists(item => item == variableName))
+            {
+                if (targetType.Exists(item => item == variableType))
+                    return;
+
+                var diagnostic = Diagnostic.Create(Rule, context.ContainingSymbol.Locations[0], variableName, variableType);
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
+}

--- a/Azure.MgmtSdk.Analyzers/DataPropertyEtagAnalyzer.cs
+++ b/Azure.MgmtSdk.Analyzers/DataPropertyEtagAnalyzer.cs
@@ -1,0 +1,82 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+using System;
+using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+
+namespace Azure.MgmtSdk.Analyzers
+{
+    /// <summary>
+    /// Analyzer to check resource type 'ResouceType'.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class DataPropertyEtagAnalyzer : DiagnosticAnalyzer
+    {
+        protected static readonly string Title = "Improper public data property";
+        protected static readonly string MessageFormat = "The data type of a property name '{0}' is '{1}'.";
+        protected static readonly string Description = "Consider to change it to Etag.";
+
+        public const string DiagnosticIdDataPropertyETagName = "AZM0043";
+
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticIdDataPropertyETagName, Title,
+            MessageFormat, DiagnosticCategory.Naming, DiagnosticSeverity.Warning, isEnabledByDefault: true,
+            description: Description);
+
+        private static readonly Regex suffixRegex = new Regex(".+(?<Suffix>([Ee][Tt]ag))$");
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(SyntaxAnalyzeDataPropertyEtagVariableName, SyntaxKind.VariableDeclaration);
+            context.RegisterSyntaxNodeAction(SyntaxAnalyzeDataPropertyEtagPropertyName, SyntaxKind.PropertyDeclaration);
+        }
+
+        private void SyntaxAnalyzeDataPropertyEtagVariableName(SyntaxNodeAnalysisContext context)
+        {
+            VariableDeclarationSyntax node = (VariableDeclarationSyntax)context.Node;
+            var variableName = node.Variables.ToString();
+            var variableType = node.Type;
+
+            var match = suffixRegex.Match(variableName);
+
+            Console.WriteLine(variableType.ToString());
+
+            if (match.Success || variableName == "Etag")
+            {
+                if (variableType.ToString().Contains("ETag") || variableType.ToString().Contains("etag"))
+                    return;
+
+                var diagnostic = Diagnostic.Create(Rule, context.ContainingSymbol.Locations[0],
+                    new Dictionary<string, string> { { "SuggestedName", variableName.Substring(0, variableName.Length) } }.ToImmutableDictionary(), variableName, variableType.ToString());
+                context.ReportDiagnostic(diagnostic);
+            }
+
+        }
+
+        private void SyntaxAnalyzeDataPropertyEtagPropertyName(SyntaxNodeAnalysisContext context)
+        {
+            PropertyDeclarationSyntax node = (PropertyDeclarationSyntax)context.Node;
+            var variableName = node.Identifier.ToString();
+            var variableType = node.Type;
+
+            var match = suffixRegex.Match(variableName);
+
+            if (match.Success || variableName == "Etag")
+            {
+                if (variableType.ToString().Contains("ETag") || variableType.ToString().Contains("etag"))
+                    return;
+
+                var diagnostic = Diagnostic.Create(Rule, context.ContainingSymbol.Locations[0],
+                    new Dictionary<string, string> { { "SuggestedName", variableName.Substring(0, variableName.Length) } }.ToImmutableDictionary(), variableName, variableType.ToString());
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+
+    }
+}

--- a/Azure.MgmtSdk.Analyzers/DataPropertyEtagAnalyzer.cs
+++ b/Azure.MgmtSdk.Analyzers/DataPropertyEtagAnalyzer.cs
@@ -15,9 +15,9 @@ namespace Azure.MgmtSdk.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class DataPropertyEtagAnalyzer : DiagnosticAnalyzer
     {
-        protected static readonly string Title = "Improper public data property";
-        protected static readonly string MessageFormat = "The data type of a property name '{0}' is '{1}'.";
-        protected static readonly string Description = "Consider to change it to Etag.";
+        protected static readonly string Title = "Potential improper data type of propert";
+        protected static readonly string MessageFormat = "Property {0} looks like an ETag.";
+        protected static readonly string Description = "Check the real return value and consider changing the type to \"ETag\".";
 
         public const string DiagnosticId = "AZM0043";
 
@@ -73,7 +73,7 @@ namespace Azure.MgmtSdk.Analyzers
                     return;
 
                 var diagnostic = Diagnostic.Create(Rule, context.ContainingSymbol.Locations[0],
-                    new Dictionary<string, string> { { "SuggestedName", variableName.Substring(0, variableName.Length) } }.ToImmutableDictionary(), variableName, variableType.ToString());
+                    new Dictionary<string, string> { { "SuggestedName", variableName.Substring(0, variableName.Length) } }.ToImmutableDictionary(), variableName);
                 context.ReportDiagnostic(diagnostic);
             }
         }

--- a/Azure.MgmtSdk.Analyzers/DataPropertyEtagAnalyzer.cs
+++ b/Azure.MgmtSdk.Analyzers/DataPropertyEtagAnalyzer.cs
@@ -41,21 +41,6 @@ namespace Azure.MgmtSdk.Analyzers
             var variableName = node.Variables.ToString();
             var variableType = node.Type.ToString();
             MatchAndDiagnostic(suffixRegex, variableName, variableType, targetName, targetType, Rule, context);
-
-            //var match = suffixRegex.Match(variableName);
-
-            //Console.WriteLine(variableType.ToString());
-
-            //if (match.Success || variableName == "Etag")
-            //{
-            //    if (variableType.ToString().Contains("ETag") || variableType.ToString().Contains("etag"))
-            //        return;
-
-            //    var diagnostic = Diagnostic.Create(Rule, context.ContainingSymbol.Locations[0],
-            //        new Dictionary<string, string> { { "SuggestedName", variableName.Substring(0, variableName.Length) } }.ToImmutableDictionary(), variableName, variableType.ToString());
-            //    context.ReportDiagnostic(diagnostic);
-            //}
-
         }
 
         private void SyntaxAnalyzeDataPropertyEtagPropertyName(SyntaxNodeAnalysisContext context)
@@ -64,18 +49,6 @@ namespace Azure.MgmtSdk.Analyzers
             var variableName = node.Identifier.ToString();
             var variableType = node.Type.ToString();
             MatchAndDiagnostic(suffixRegex, variableName, variableType, targetName, targetType, Rule, context);
-
-            //var match = suffixRegex.Match(variableName);
-
-            //if (match.Success || variableName == "Etag")
-            //{
-            //    if (variableType.ToString().Contains("ETag") || variableType.ToString().Contains("etag"))
-            //        return;
-
-            //    var diagnostic = Diagnostic.Create(Rule, context.ContainingSymbol.Locations[0], variableName);
-            //        //new Dictionary<string, string> { { "SuggestedName", variableName.Substring(0, variableName.Length) } }.ToImmutableDictionary(), variableName);
-            //    context.ReportDiagnostic(diagnostic);
-            //}
         }
 
     }

--- a/Azure.MgmtSdk.Analyzers/DataPropertyEtagAnalyzer.cs
+++ b/Azure.MgmtSdk.Analyzers/DataPropertyEtagAnalyzer.cs
@@ -19,13 +19,13 @@ namespace Azure.MgmtSdk.Analyzers
         protected static readonly string MessageFormat = "The data type of a property name '{0}' is '{1}'.";
         protected static readonly string Description = "Consider to change it to Etag.";
 
-        public const string DiagnosticIdDataPropertyETagName = "AZM0043";
+        public const string DiagnosticId = "AZM0043";
 
-        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticIdDataPropertyETagName, Title,
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title,
             MessageFormat, DiagnosticCategory.Naming, DiagnosticSeverity.Warning, isEnabledByDefault: true,
             description: Description);
 
-        private static readonly Regex suffixRegex = new Regex(".+(?<Suffix>([Ee][Tt]ag))$");
+        private static readonly Regex suffixRegex = new Regex(".+(?<Suffix>(E[Tt]ag))$");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/Azure.MgmtSdk.Analyzers/DataPropertyEtagAnalyzer.cs
+++ b/Azure.MgmtSdk.Analyzers/DataPropertyEtagAnalyzer.cs
@@ -13,19 +13,17 @@ namespace Azure.MgmtSdk.Analyzers
     /// Analyzer to check resource type 'ResouceType'.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class DataPropertyEtagAnalyzer : DiagnosticAnalyzer
+    public class DataPropertyEtagAnalyzer : DataPropertyAnalyzerBase
     {
-        protected static readonly string Title = "Potential improper data type of propert";
-        protected static readonly string MessageFormat = "Property {0} looks like an ETag.";
-        protected static readonly string Description = "Check the real return value and consider changing the type to \"ETag\".";
-
         public const string DiagnosticId = "AZM0043";
 
         private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title,
-            MessageFormat, DiagnosticCategory.Naming, DiagnosticSeverity.Warning, isEnabledByDefault: true,
+            MessageFormat, DiagnosticCategory.Naming, DiagnosticSeverity.Info, isEnabledByDefault: true,
             description: Description);
 
-        private static readonly Regex suffixRegex = new Regex(".+(?<Suffix>(E[Tt]ag))$");
+        private static readonly Regex suffixRegex = new Regex("");
+        protected static List<string> targetName = new List<string> { "Etag", "ETag" };
+        protected static List<string> targetType = new List<string> { "ETag", "ETag?", "Azure.Core.ETag", "Azure.Core.ETag?" };
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
@@ -41,21 +39,22 @@ namespace Azure.MgmtSdk.Analyzers
         {
             VariableDeclarationSyntax node = (VariableDeclarationSyntax)context.Node;
             var variableName = node.Variables.ToString();
-            var variableType = node.Type;
+            var variableType = node.Type.ToString();
+            MatchAndDiagnostic(suffixRegex, variableName, variableType, targetName, targetType, Rule, context);
 
-            var match = suffixRegex.Match(variableName);
+            //var match = suffixRegex.Match(variableName);
 
-            Console.WriteLine(variableType.ToString());
+            //Console.WriteLine(variableType.ToString());
 
-            if (match.Success || variableName == "Etag")
-            {
-                if (variableType.ToString().Contains("ETag") || variableType.ToString().Contains("etag"))
-                    return;
+            //if (match.Success || variableName == "Etag")
+            //{
+            //    if (variableType.ToString().Contains("ETag") || variableType.ToString().Contains("etag"))
+            //        return;
 
-                var diagnostic = Diagnostic.Create(Rule, context.ContainingSymbol.Locations[0],
-                    new Dictionary<string, string> { { "SuggestedName", variableName.Substring(0, variableName.Length) } }.ToImmutableDictionary(), variableName, variableType.ToString());
-                context.ReportDiagnostic(diagnostic);
-            }
+            //    var diagnostic = Diagnostic.Create(Rule, context.ContainingSymbol.Locations[0],
+            //        new Dictionary<string, string> { { "SuggestedName", variableName.Substring(0, variableName.Length) } }.ToImmutableDictionary(), variableName, variableType.ToString());
+            //    context.ReportDiagnostic(diagnostic);
+            //}
 
         }
 
@@ -63,19 +62,20 @@ namespace Azure.MgmtSdk.Analyzers
         {
             PropertyDeclarationSyntax node = (PropertyDeclarationSyntax)context.Node;
             var variableName = node.Identifier.ToString();
-            var variableType = node.Type;
+            var variableType = node.Type.ToString();
+            MatchAndDiagnostic(suffixRegex, variableName, variableType, targetName, targetType, Rule, context);
 
-            var match = suffixRegex.Match(variableName);
+            //var match = suffixRegex.Match(variableName);
 
-            if (match.Success || variableName == "Etag")
-            {
-                if (variableType.ToString().Contains("ETag") || variableType.ToString().Contains("etag"))
-                    return;
+            //if (match.Success || variableName == "Etag")
+            //{
+            //    if (variableType.ToString().Contains("ETag") || variableType.ToString().Contains("etag"))
+            //        return;
 
-                var diagnostic = Diagnostic.Create(Rule, context.ContainingSymbol.Locations[0],
-                    new Dictionary<string, string> { { "SuggestedName", variableName.Substring(0, variableName.Length) } }.ToImmutableDictionary(), variableName);
-                context.ReportDiagnostic(diagnostic);
-            }
+            //    var diagnostic = Diagnostic.Create(Rule, context.ContainingSymbol.Locations[0], variableName);
+            //        //new Dictionary<string, string> { { "SuggestedName", variableName.Substring(0, variableName.Length) } }.ToImmutableDictionary(), variableName);
+            //    context.ReportDiagnostic(diagnostic);
+            //}
         }
 
     }

--- a/Azure.MgmtSdk.Analyzers/DataPropertyResourceIdentifierAnalyzer.cs
+++ b/Azure.MgmtSdk.Analyzers/DataPropertyResourceIdentifierAnalyzer.cs
@@ -15,9 +15,9 @@ namespace Azure.MgmtSdk.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class DataPropertyResourceIdentifierAnalyzer : DiagnosticAnalyzer
     {
-        protected static readonly string Title = "Improper public data property";
-        protected static readonly string MessageFormat = "The data type of a property name '{0}' is '{1}'.";
-        protected static readonly string Description = "Consider to change it to ResourceIdentifier.";
+        protected static readonly string Title = "Potential improper data type of propert";
+        protected static readonly string MessageFormat = "Property {0} looks like a ResourceIdentifier.";
+        protected static readonly string Description = "Check the real return value and consider changing the type to \"ResourceIdentifier\".";
 
         public const string DiagnosticId = "AZM0041";
 

--- a/Azure.MgmtSdk.Analyzers/DataPropertyResourceIdentifierAnalyzer.cs
+++ b/Azure.MgmtSdk.Analyzers/DataPropertyResourceIdentifierAnalyzer.cs
@@ -19,9 +19,9 @@ namespace Azure.MgmtSdk.Analyzers
         protected static readonly string MessageFormat = "The data type of a property name '{0}' is '{1}'.";
         protected static readonly string Description = "Consider to change it to ResourceIdentifier.";
 
-        public const string DiagnosticIdDataPropertyResourceIdentifierName = "AZM0041";
+        public const string DiagnosticId = "AZM0041";
 
-        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticIdDataPropertyResourceIdentifierName, Title,
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title,
             MessageFormat, DiagnosticCategory.Naming, DiagnosticSeverity.Warning, isEnabledByDefault: true,
             description: Description);
 

--- a/Azure.MgmtSdk.Analyzers/DataPropertyResourceIdentifierAnalyzer.cs
+++ b/Azure.MgmtSdk.Analyzers/DataPropertyResourceIdentifierAnalyzer.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+using System;
+using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+
+namespace Azure.MgmtSdk.Analyzers
+{
+    /// <summary>
+    /// Analyzer to check resource type 'ResourceIdentifier'.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class DataPropertyResourceIdentifierAnalyzer : DiagnosticAnalyzer
+    {
+        protected static readonly string Title = "Improper public data property";
+        protected static readonly string MessageFormat = "The data type of a property name '{0}' is '{1}'.";
+        protected static readonly string Description = "Consider to change it to ResourceIdentifier.";
+
+        public const string DiagnosticIdDataPropertyResourceIdentifierName = "AZM0041";
+
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticIdDataPropertyResourceIdentifierName, Title,
+            MessageFormat, DiagnosticCategory.Naming, DiagnosticSeverity.Warning, isEnabledByDefault: true,
+            description: Description);
+
+        private static readonly Regex suffixRegex = new Regex(".+(?<Suffix>(Id))$");
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(SyntaxAnalyzeDataPropertyResourceIdentifierVariableName, SyntaxKind.VariableDeclaration);
+            context.RegisterSyntaxNodeAction(SyntaxAnalyzeDataPropertyResourceIdentifierPropertyName, SyntaxKind.PropertyDeclaration);
+        }
+
+        private void SyntaxAnalyzeDataPropertyResourceIdentifierVariableName(SyntaxNodeAnalysisContext context)
+        {
+            VariableDeclarationSyntax node = (VariableDeclarationSyntax)context.Node;
+            var variableName = node.Variables.ToString();
+            var variableType = node.Type;
+
+            var match = suffixRegex.Match(variableName);
+
+            if (match.Success)
+            {
+                if (variableType.ToString().Contains("ResourceIdentifier")) // ResourceIdentifier and Azure.Core.ResourceIdentifier
+                    return;
+
+                var diagnostic = Diagnostic.Create(Rule, context.ContainingSymbol.Locations[0],
+                    new Dictionary<string, string> { { "SuggestedName", variableName.Substring(0, variableName.Length) } }.ToImmutableDictionary(), variableName, variableType.ToString());
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+
+        private void SyntaxAnalyzeDataPropertyResourceIdentifierPropertyName(SyntaxNodeAnalysisContext context)
+        {
+            PropertyDeclarationSyntax node = (PropertyDeclarationSyntax)context.Node;
+            var variableName = node.Identifier.ToString();
+            var variableType = node.Type;
+
+            var match = suffixRegex.Match(variableName);
+
+            if (match.Success)
+            {
+                if (variableType.ToString().Contains("ResourceIdentifier")) // ResourceIdentifier and Azure.Core.ResourceIdentifier
+                    return;
+
+                var diagnostic = Diagnostic.Create(Rule, context.ContainingSymbol.Locations[0],
+                    new Dictionary<string, string> { { "SuggestedName", variableName.Substring(0, variableName.Length) } }.ToImmutableDictionary(), variableName, variableType.ToString());
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+
+    }
+}

--- a/Azure.MgmtSdk.Analyzers/DataPropertyResourceIdentifierAnalyzer.cs
+++ b/Azure.MgmtSdk.Analyzers/DataPropertyResourceIdentifierAnalyzer.cs
@@ -22,7 +22,7 @@ namespace Azure.MgmtSdk.Analyzers
         public const string DiagnosticId = "AZM0041";
 
         private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title,
-            MessageFormat, DiagnosticCategory.Naming, DiagnosticSeverity.Warning, isEnabledByDefault: true,
+            MessageFormat, DiagnosticCategory.Naming, DiagnosticSeverity.Info, isEnabledByDefault: true,
             description: Description);
 
         private static readonly Regex suffixRegex = new Regex(".+(?<Suffix>(Id))$");
@@ -70,7 +70,7 @@ namespace Azure.MgmtSdk.Analyzers
                     return;
 
                 var diagnostic = Diagnostic.Create(Rule, context.ContainingSymbol.Locations[0],
-                    new Dictionary<string, string> { { "SuggestedName", variableName.Substring(0, variableName.Length) } }.ToImmutableDictionary(), variableName, variableType.ToString());
+                    new Dictionary<string, string> { { "SuggestedName", variableName.Substring(0, variableName.Length) } }.ToImmutableDictionary(), variableName);
                 context.ReportDiagnostic(diagnostic);
             }
         }

--- a/Azure.MgmtSdk.Analyzers/DataPropertyResourceTypeAnalyzer.cs
+++ b/Azure.MgmtSdk.Analyzers/DataPropertyResourceTypeAnalyzer.cs
@@ -15,9 +15,9 @@ namespace Azure.MgmtSdk.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class DataPropertyResourceTypeAnalyzer : DiagnosticAnalyzer
     {
-        protected static readonly string Title = "Improper public data property";
-        protected static readonly string MessageFormat = "The data type of a property name '{0}' is '{1}'.";
-        protected static readonly string Description = "Consider to change it to ResourceType.";
+        protected static readonly string Title = "Potential improper data type of propert";
+        protected static readonly string MessageFormat = "Property {0} looks like a ResourceType.";
+        protected static readonly string Description = "Check the real return value and consider changing the type to \"ResourceType\".";
 
         public const string DiagnosticId = "AZM0042";
 

--- a/Azure.MgmtSdk.Analyzers/DataPropertyResourceTypeAnalyzer.cs
+++ b/Azure.MgmtSdk.Analyzers/DataPropertyResourceTypeAnalyzer.cs
@@ -22,7 +22,7 @@ namespace Azure.MgmtSdk.Analyzers
         public const string DiagnosticId = "AZM0042";
 
         private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title,
-            MessageFormat, DiagnosticCategory.Naming, DiagnosticSeverity.Warning, isEnabledByDefault: true,
+            MessageFormat, DiagnosticCategory.Naming, DiagnosticSeverity.Info, isEnabledByDefault: true,
             description: Description);
 
         private static readonly Regex suffixRegex = new Regex(".+(?<Suffix>(Type))$");
@@ -70,7 +70,7 @@ namespace Azure.MgmtSdk.Analyzers
                     return;
 
                 var diagnostic = Diagnostic.Create(Rule, context.ContainingSymbol.Locations[0],
-                    new Dictionary<string, string> { { "SuggestedName", variableName.Substring(0, variableName.Length) } }.ToImmutableDictionary(), variableName, variableType.ToString());
+                    new Dictionary<string, string> { { "SuggestedName", variableName.Substring(0, variableName.Length) } }.ToImmutableDictionary(), variableName);
                 context.ReportDiagnostic(diagnostic);
             }
         }

--- a/Azure.MgmtSdk.Analyzers/DataPropertyResourceTypeAnalyzer.cs
+++ b/Azure.MgmtSdk.Analyzers/DataPropertyResourceTypeAnalyzer.cs
@@ -19,9 +19,9 @@ namespace Azure.MgmtSdk.Analyzers
         protected static readonly string MessageFormat = "The data type of a property name '{0}' is '{1}'.";
         protected static readonly string Description = "Consider to change it to ResourceType.";
 
-        public const string DiagnosticIdDataPropertyResourceTypeName = "AZM0042";
+        public const string DiagnosticId = "AZM0042";
 
-        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticIdDataPropertyResourceTypeName, Title,
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title,
             MessageFormat, DiagnosticCategory.Naming, DiagnosticSeverity.Warning, isEnabledByDefault: true,
             description: Description);
 

--- a/Azure.MgmtSdk.Analyzers/DataPropertyResourceTypeAnalyzer.cs
+++ b/Azure.MgmtSdk.Analyzers/DataPropertyResourceTypeAnalyzer.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+using System;
+using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+
+namespace Azure.MgmtSdk.Analyzers
+{
+    /// <summary>
+    /// Analyzer to check resource type 'ResouceType'.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class DataPropertyResourceTypeAnalyzer : DiagnosticAnalyzer
+    {
+        protected static readonly string Title = "Improper public data property";
+        protected static readonly string MessageFormat = "The data type of a property name '{0}' is '{1}'.";
+        protected static readonly string Description = "Consider to change it to ResourceType.";
+
+        public const string DiagnosticIdDataPropertyResourceTypeName = "AZM0042";
+
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticIdDataPropertyResourceTypeName, Title,
+            MessageFormat, DiagnosticCategory.Naming, DiagnosticSeverity.Warning, isEnabledByDefault: true,
+            description: Description);
+
+        private static readonly Regex suffixRegex = new Regex(".+(?<Suffix>(Type))$");
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(SyntaxAnalyzeDataPropertyResourceTypeVariableName, SyntaxKind.VariableDeclaration);
+            context.RegisterSyntaxNodeAction(SyntaxAnalyzeDataPropertyResourceTypePropertyName, SyntaxKind.PropertyDeclaration);
+        }
+
+        private void SyntaxAnalyzeDataPropertyResourceTypeVariableName(SyntaxNodeAnalysisContext context)
+        {
+            VariableDeclarationSyntax node = (VariableDeclarationSyntax)context.Node;
+            var variableName = node.Variables.ToString();
+            var variableType = node.Type;
+
+            var match = suffixRegex.Match(variableName);
+
+            if (match.Success || variableName == "ResourceType") // its name is 'ResourceType' or end with 'Type'
+            {
+                if (variableType.ToString().Contains("ResourceType")) // ResourceType and Azure.Core.ResourceType
+                    return;
+                var diagnostic = Diagnostic.Create(Rule, context.ContainingSymbol.Locations[0],
+                    new Dictionary<string, string> { { "SuggestedName", variableName.Substring(0, variableName.Length) } }.ToImmutableDictionary(), variableName, variableType.ToString());
+                context.ReportDiagnostic(diagnostic);
+            }
+
+        }
+
+        private void SyntaxAnalyzeDataPropertyResourceTypePropertyName(SyntaxNodeAnalysisContext context)
+        {
+            PropertyDeclarationSyntax node = (PropertyDeclarationSyntax)context.Node;
+            var variableName = node.Identifier.ToString();
+            var variableType = node.Type;
+
+            var match = suffixRegex.Match(variableName);
+
+            if (match.Success || variableName == "ResourceType") // its name is 'ResourceType' or end with 'Type'
+            {
+                if (variableType.ToString().Contains("ResourceType")) // ResourceType and Azure.Core.ResourceType
+                    return;
+
+                var diagnostic = Diagnostic.Create(Rule, context.ContainingSymbol.Locations[0],
+                    new Dictionary<string, string> { { "SuggestedName", variableName.Substring(0, variableName.Length) } }.ToImmutableDictionary(), variableName, variableType.ToString());
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+
+    }
+}

--- a/Azure.MgmtSdk.Analyzers/ModelNameSuffixAnalyzerMethods.cs
+++ b/Azure.MgmtSdk.Analyzers/ModelNameSuffixAnalyzerMethods.cs
@@ -16,11 +16,11 @@ namespace Azure.MgmtSdk.Analyzers
 
     public class ModelNameSuffixGeneralAnalyzer : ModelNameSuffixAnalyzerBase
     {
-        public const string DiagnosticIdGeneral = "AZM0010";
+        public const string DiagnosticId = "AZM0010";
 
         private static readonly HashSet<string> ReservedNames = new HashSet<string> { "ErrorResponse" };
 
-        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticIdGeneral, Title,
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title,
             MessageFormat, DiagnosticCategory.Naming, DiagnosticSeverity.Warning, isEnabledByDefault: true,
             description: Description);
 
@@ -62,9 +62,9 @@ namespace Azure.MgmtSdk.Analyzers
 
     public class ModelNameSuffixDefinitionAnalyzer : ModelNameSuffixAnalyzerBase
     {
-        public const string DiagnosticIdDefinition = "AZM0011";
+        public const string DiagnosticId = "AZM0011";
 
-        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticIdDefinition, Title,
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title,
             MessageFormat, DiagnosticCategory.Naming, DiagnosticSeverity.Warning, isEnabledByDefault: true,
             description: Description);
 
@@ -107,9 +107,9 @@ namespace Azure.MgmtSdk.Analyzers
 
     public class ModelNameSuffixDataAnalyzer : ModelNameSuffixAnalyzerBase
     {
-        public const string DiagnosticIdData = "AZM0012";
+        public const string DiagnosticId = "AZM0012";
 
-        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticIdData, Title,
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title,
             MessageFormat, DiagnosticCategory.Naming, DiagnosticSeverity.Warning, isEnabledByDefault: true,
             description: Description);
 
@@ -152,9 +152,9 @@ namespace Azure.MgmtSdk.Analyzers
 
     public class ModelNameSuffixOperationAnalyzer : ModelNameSuffixAnalyzerBase
     {
-        public const string DiagnosticIdOperation = "AZM0013";
+        public const string DiagnosticId = "AZM0013";
 
-        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticIdOperation, Title,
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title,
             MessageFormat, DiagnosticCategory.Naming, DiagnosticSeverity.Warning, isEnabledByDefault: true,
             description: Description);
 
@@ -201,9 +201,9 @@ namespace Azure.MgmtSdk.Analyzers
 
     public class ModelNameSuffixResourceAnalyzer : ModelNameSuffixAnalyzerBase
     {
-        public const string DiagnosticIdResource = "AZM0014";
+        public const string DiagnosticId = "AZM0014";
 
-        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticIdResource, Title,
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title,
             MessageFormat, DiagnosticCategory.Naming, DiagnosticSeverity.Warning, isEnabledByDefault: true,
             description: Description);
 

--- a/Azure.MgmtSdk.Analyzers/PublicBoolPropertyNameAnalyzer.cs
+++ b/Azure.MgmtSdk.Analyzers/PublicBoolPropertyNameAnalyzer.cs
@@ -19,9 +19,9 @@ namespace Azure.MgmtSdk.Analyzers
         protected static readonly string MessageFormat = "Property name '{0}' ends with '{1}'";
         protected static readonly string Description = "PropertyName is not recommended. Consider to add a verb as prefix.";
 
-        public const string DiagnosticIdPublicBoolPropertyName = "AZM0020";
+        public const string DiagnosticId = "AZM0020";
 
-        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticIdPublicBoolPropertyName, Title,
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title,
             MessageFormat, DiagnosticCategory.Naming, DiagnosticSeverity.Warning, isEnabledByDefault: true,
             description: Description);
 

--- a/README.md
+++ b/README.md
@@ -30,3 +30,28 @@ Take NetworkFunction as an example.
   </ItemGroup>
 ```
 5. Command `dotnet clean; dotnet build` in command line to clean previous settings and finish the SDK Generation process.
+
+
+## Rules
+
+### Finished
+- [x] Avoid using Parameter(s), Request, Options and Response as the suffix in model.
+- [x] Avoid using reserved names Collection, Resource as model suffix. Avoid using Data as model suffix unless the model derives from ResourceData/TrackedResourceData. 
+- [x] Avoid using Definition as model suffix unless it's the name of a Resource. 
+- [x] Avoid using Operation as model suffix unless the model derives from Operation<T>.
+
+### TODO
+1. Property with type bool should start with a verb, like 'Is', 'Can', 'Has' prefix.
+2. The data type of a property should be 'uuid' if its name is end of 'Id' / 'Guid' and value is really a uuid. 
+3. The data type of a property should be 'ResourceIdentifier' if its name is end of 'Id' and value is really a ResourceIdentifier. 
+4. The data type of a property should be 'ResouceType' if its name is 'ResourceType' or end with 'Type' and the value is really a ResourceType('Microsoft.xxxxx/xxxx'). 
+5. The data type of a property should be 'ETag' if its name is 'etag' and the value is really a ETag. The property name  should be 'ETag'(Optional). 
+6. The data type of a property might be 'AzureLocation' if its name is end with 'location' / 'locations' . 
+7. For all `CheckNameAvailability` operation:
+  The method name should be `Check[Resource/RP name]NameAvailability`
+  The parameter / response model name should be `[Resource/RP name]NameAvailabilityXXX`
+
+8. roperty/parameter usually ends with 'On'. It's auto-renamed by the generator, but watch out for exceptions.  
+  Special case, 'start' and 'end' use root form, that are 'startOn' and 'endOn', others usually use past tense, like 'CreatedOn', 'EstablishedOn'
+
+


### PR DESCRIPTION
I add three analyzer modules for three data property rules.
With three unitests.

• The data type of a property should be 'ResourceIdentifier' if its name is end of 'Id' and value is really a ResourceIdentifier.
• The data type of a property should be 'ResouceType' if its name is 'ResourceType' or end with 'Type' and the value is really a ResourceType('Microsoft.xxxxx/xxxx'). 
• The data type of a property should be 'ETag' if its name is 'etag' and the value is really a ETag. The property name should be 'ETag'(Optional).